### PR TITLE
Improve docker support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qdivision/chip",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Easily manage microservices and infrastructure for local development",
   "files": [
     "build/",

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -11,15 +11,19 @@ import { PROJECT_NAME } from '../utils/files';
 const dockerServices = async () => {
   if (!docker.isPresent()) return [];
   const services = await docker.listServices();
-  return services.map(({ name, image, status, ports }) => [
-    name,
-    image ?? '',
-    status ?? '',
-    ' 🐳',
-    ports ?? '',
-    '',
-    '',
-  ]);
+  return services.map(({ name, image, status, ports, tags }) => {
+    const allTags = tags.join(', ') || '';
+
+    return [
+      name,
+      image ?? '',
+      status ?? '',
+      ' 🐳',
+      ports ?? '',
+      '',
+      allTags.substring(0, 30) + (allTags.length > 30 ? '...' : ''),
+    ];
+  });
 };
 
 // TODO: Log orphans

--- a/src/subcommands/start.ts
+++ b/src/subcommands/start.ts
@@ -13,11 +13,11 @@ export const startService = async (
   env: { [envVar: string]: string },
   secrets: { [envVar: string]: string },
 ) => {
-  log`Starting service {bold ${serviceName}}`;
-
   if (isPresent(serviceName)) {
     await up([], serviceName)
   }
+
+  log`Starting service {bold ${serviceName}}`;
 
   const { setup, setupService } = await readScripts();
 

--- a/src/subcommands/start.ts
+++ b/src/subcommands/start.ts
@@ -5,6 +5,7 @@ import { log } from '../utils/log';
 import { persistPid, getActiveProcesses, createLogStream } from '../utils/ps';
 import { execDetached } from '../utils/processes';
 import { printError } from '../utils/errors';
+import {isPresent, up} from '../utils/docker';
 
 export const startService = async (
   serviceName: string,
@@ -13,6 +14,10 @@ export const startService = async (
   secrets: { [envVar: string]: string },
 ) => {
   log`Starting service {bold ${serviceName}}`;
+
+  if (isPresent(serviceName)) {
+    await up([], serviceName)
+  }
 
   const { setup, setupService } = await readScripts();
 

--- a/src/subcommands/stop.ts
+++ b/src/subcommands/stop.ts
@@ -6,8 +6,13 @@ import { processExists, getActiveProcesses } from '../utils/ps';
 import { PROJECT_NAME } from '../utils/files';
 import { printError } from '../utils/errors';
 import { readServices } from '../utils/config';
+import { isPresent, stop } from '../utils/docker';
 
 export const stopProcess = async (name: string, pid: number) => {
+  if (isPresent(name)) {
+    await stop([], name);
+  }
+
   console.log(chalk`Stopping {bold ${name}} with pid {bold ${pid}}`);
   if (await processExists(pid)) {
     // https://stackoverflow.com/a/8406413

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,6 +17,13 @@ export interface ChipConfig {
         }
       | undefined;
   };
+  containers?: {
+    [name: string]:
+      | {
+          tags?: string[];
+        }
+      | undefined;
+  };
 }
 
 export interface ChipSecrets {

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -5,7 +5,7 @@ import { green, red } from 'chalk';
 
 import { CWD } from '../utils/files';
 import { exec } from '../utils/processes';
-import {readConfig} from './config';
+import { readConfig } from './config';
 
 const capitalize = (value: string) =>
   value.substring(0, 1).toUpperCase() + value.substring(1).toLowerCase();
@@ -27,14 +27,14 @@ export const isPresent = (subDirectory?: string) => fs.existsSync(`${CWD}${subDi
  * If no services are specified, all of them will be started.
  */
 export const up = async (services: string[] = [], subDirectory?: string) =>
-  exec(`docker compose up ${subDirectory ? `-f ${subDirectory}/docker-compose.yml` : ''} -d ${services.join(' ')}`, { cwd: CWD, live: true });
+  exec(`docker compose ${subDirectory ? `-f ${subDirectory}/docker-compose.yml` : ''} up -d ${services.join(' ')}`, { cwd: CWD, live: true });
 
 /**
  * Stop specified docker-compose services in this project.
  * If no services are specified, all of them will be stopped.
  */
-export const stop = async (services: string[] = []) =>
-  exec(`docker compose stop ${services.join(' ')}`, { cwd: CWD, live: true });
+export const stop = async (services: string[] = [], subDirectory?: string) =>
+  exec(`docker compose ${subDirectory ? `-f ${subDirectory}/docker-compose.yml` : ''} stop ${services.join(' ')}`, { cwd: CWD, live: true });
 
 /**
  * Restart specified docker-compose services in this project.
@@ -57,26 +57,31 @@ export const rm = async (services: string[] = []) =>
   });
 
 export const composeServices = async (): Promise<{
-  [serviceName: string]: { image: string };
+  [serviceName: string]: { image: string, tags: string[] };
 }> => {
   const composeYml = await fs.readFile(`${CWD}/docker-compose.yml`, 'utf8');
   const composeConfig = (await yaml.safeLoad(composeYml)) as any;
-  return composeConfig?.services ?? {};
+  const services = composeConfig?.services ?? {};
+  const config = await readConfig();
+  return Object.fromEntries(
+    Object.entries(services)
+      .map(([key, value]) => [key, {
+        ...(value as any),
+        tags: config.containers?.[key]?.tags || []
+      }])
+  );
 };
 
 /** Get names of docker-compose services in this project. */
 export const composeServiceNames = async (serviceWhitelist?: string[]) => {
-  const allServices = Object.keys(await composeServices());
+  const allServices = await composeServices();
 
-  if (!serviceWhitelist) return allServices;
+  if (!serviceWhitelist) return Object.keys(allServices);
 
-  const config = await readConfig();
-  return allServices.filter((n) =>
-    serviceWhitelist.includes(n)
-    || (config.containers
-      && config.containers[n]?.tags?.some((tag) => serviceWhitelist.includes(tag))
-    )
-  );
+  return Object.entries(allServices).filter(([name, { tags }]) =>
+    serviceWhitelist.includes(name)
+    || tags.some((tag) => serviceWhitelist.includes(tag))
+  ).map(([name]) => name);
 };
 
 /** Returns a list of all services in the `docker-compose.yml` file */
@@ -96,7 +101,7 @@ export const listServices = async () => {
     }))
     .filter(({ projectDir }) => resolve(projectDir) === CWD);
 
-  return Object.entries(services).map(([serviceName, { image }]) => {
+  return Object.entries(services).map(([serviceName, { image, tags }]) => {
     const info = runningServices.find((s) => s.serviceName === serviceName);
     return {
       name: serviceName,
@@ -109,6 +114,7 @@ export const listServices = async () => {
             .map((p) => p.match(/\b\d+(?=\/tcp\b)/)?.[0])
             .join(', ')
         : '',
+      tags,
     };
   });
 };

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -5,6 +5,7 @@ import { green, red } from 'chalk';
 
 import { CWD } from '../utils/files';
 import { exec } from '../utils/processes';
+import {readConfig} from './config';
 
 const capitalize = (value: string) =>
   value.substring(0, 1).toUpperCase() + value.substring(1).toLowerCase();
@@ -66,8 +67,16 @@ export const composeServices = async (): Promise<{
 /** Get names of docker-compose services in this project. */
 export const composeServiceNames = async (serviceWhitelist?: string[]) => {
   const allServices = Object.keys(await composeServices());
+
   if (!serviceWhitelist) return allServices;
-  return allServices.filter((n) => serviceWhitelist.includes(n));
+
+  const config = await readConfig();
+  return allServices.filter((n) =>
+    serviceWhitelist.includes(n)
+    || (config.containers
+      && config.containers[n]?.tags?.some((tag) => serviceWhitelist.includes(tag))
+    )
+  );
 };
 
 /** Returns a list of all services in the `docker-compose.yml` file */

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -20,14 +20,14 @@ const parseTable = (rawTable: string, skipRows = 0) =>
     .map((line) => line.split(/\s{3,}/g));
 
 /** Returns `true` if a `docker-compose.yml` file is present in the project */
-export const isPresent = () => fs.existsSync(`${CWD}/docker-compose.yml`);
+export const isPresent = (subDirectory?: string) => fs.existsSync(`${CWD}${subDirectory ? `/${subDirectory}` : ''}/docker-compose.yml`);
 
 /**
  * Start specified docker-compose services in this project.
  * If no services are specified, all of them will be started.
  */
-export const up = async (services: string[] = []) =>
-  exec(`docker compose up -d ${services.join(' ')}`, { cwd: CWD, live: true });
+export const up = async (services: string[] = [], subDirectory?: string) =>
+  exec(`docker compose up ${subDirectory ? `-f ${subDirectory}/docker-compose.yml` : ''} -d ${services.join(' ')}`, { cwd: CWD, live: true });
 
 /**
  * Stop specified docker-compose services in this project.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
-    "lib": ["es2018"],
+    "lib": ["es2019"],
     "allowJs": false,
     "checkJs": false,
     "declaration": true,


### PR DESCRIPTION
Allows specifying tags for compose services in `chip.yml` - for example:
```yaml
containers:
  postgresql:
    tags:
      - base
      - container
      - marketplace
  rabbitmq:
    tags:
      - base
      - container
      - marketplace
 ```

Also adds support for nested `docker-compose.yml` files in a project directory - services will be started when starting the project.